### PR TITLE
Remove outdated Mix.Task.hidden?/1 reference

### DIFF
--- a/.mix-completion-tasks.exs
+++ b/.mix-completion-tasks.exs
@@ -3,7 +3,6 @@
 Mix.Task.load_all
 
 Mix.Task.all_modules
-|>  Enum.filter(fn(x) -> not Mix.Task.hidden?(x) end)
 |>  Enum.sort
-|>  Enum.map_join(" ", fn(x) -> Mix.Task.task_name(x) end)
+|>  Enum.map_join(" ", &Mix.Task.task_name/1)
 |>  IO.write


### PR DESCRIPTION
Looks like `Mix.Task.hidden?/1` was removed from the API at some point. I looked at the Mix source and couldn't find anything like it in their CLI, so I guess there aren't any new equivalents either.
